### PR TITLE
Location Permissions

### DIFF
--- a/Source/Analytics/BMSAnalytics.swift
+++ b/Source/Analytics/BMSAnalytics.swift
@@ -216,7 +216,8 @@ public class BMSAnalytics: AnalyticsDelegate {
             return
         }
         
-        if CLLocationManager.locationServicesEnabled() && CLLocationManager.authorizationStatus() == CLAuthorizationStatus.notDetermined {
+        if BMSAnalytics.locationEnabled && CLLocationManager.locationServicesEnabled() && 
+            CLLocationManager.authorizationStatus() == CLAuthorizationStatus.notDetermined {
             self.locationManager.requestWhenInUseAuthorization()
         }
       


### PR DESCRIPTION
User is still prompted for location permissions even when false is passed to collect location in BMS Analytics initialize. 

I added a check for location enabled in the if condition to avoid using the location api when not needed.